### PR TITLE
docs(readme): Rewrite to show transformation, not features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,67 @@
 # moo.md
 
-Thoughtful plugins for Claude Code.
+Claude Code plugins that make Claude state its confidence, list failures, and think before acting.
 
-## Why This Exists
+## What Changes
 
-Under stress, I forget to think clearly.
+| Before moo.md                | After moo.md                           |
+| ---------------------------- | -------------------------------------- |
+| "This should work"           | "85% confident because [evidence]"     |
+| Builds first, searches later | Searches libraries before writing code |
+| Hopes nothing breaks         | Lists failure modes before starting    |
+| Forgets what worked          | Recalls insights from past sessions    |
 
-Pause before building. Name the unknowns. Search for prior art. Surface what could fail. Simple disciplines — gone the moment pressure hits.
+## See It In Action
 
-So I wrote them down.
+Every response ends with a verdict box:
 
-When I forget, Claude remembers.
+```
+🟢 SHIP
+╭────────────────────────────────╮
+│ 85% confident · Type 2A · 3pt  │
+├────────────────────────────────┤
+│ Alt: Manual approach (80%)     │
+│ Risk: Rate limits              │
+╰────────────────────────────────╯
+```
 
-## What It Does
+- **🟢 SHIP** (≥85%): Act now
+- **🟡 MONITOR** (70-85%): Act with monitoring
+- **🔴 RESEARCH** (<70%): Research first
 
-Clarify intent. State confidence. Identify failure modes. Ship with honesty.
+## What Runs Quietly
 
-Your thinking compounds across sessions.
+Before responding, Claude checks:
+
+- Intent clear?
+- Libraries searched?
+- Failure modes listed?
+- Confidence stated?
+- Reversibility assessed?
+
+30+ thinking tools run automatically: Inversion, Pre-Mortem, Ishikawa, Five Whys, Decision Matrix.
 
 ## Install
 
-Requires SSH key with repo access.
-
 ```bash
-# Claude Code
-/plugin marketplace add git@github.com:saadshahd/moo.md.git
+/plugin marketplace add saadshahd/moo.md
 /plugin install hope@moo.md
 ```
 
-## Quick Start
+## Plugins
 
-Three keywords to remember:
-
-| Say this | Get this |
-|----------|----------|
-| "delve into how X works" | Deep code investigation |
-| "plan building X" | Structured plan with intent clarification |
-| "recall what I learned about X" | Surface insights from past sessions |
-
-Try one:
-
-```
-delve into how authentication works in this repo
-```
+| Plugin                                 | What It Does                                                     |
+| -------------------------------------- | ---------------------------------------------------------------- |
+| [hope](docs/plugins/hope.md)           | Core thinking system — confidence gates, silent audit, workflows |
+| [product](docs/plugins/product.md)     | PRDs, competitive analysis, metrics                              |
+| [wordsmith](docs/plugins/wordsmith.md) | Editing, voice extraction, narrative                             |
+| [founder](docs/plugins/founder.md)     | Idea validation, pitch decks, financials                         |
+| [career](docs/plugins/career.md)       | Interview prep, skill gaps, stakeholder navigation               |
 
 ## Documentation
 
 - [5-Minute Start](docs/getting-started.md) — Install and see value immediately
-- [Learnings System](docs/learnings-system.md) — How your thinking compounds
-
-**Plugin Reference:**
-- [hope](docs/plugins/hope.md) — cognitive operating system
-- [product](docs/plugins/product.md) — PRDs, competitive analysis, metrics
-- [wordsmith](docs/plugins/wordsmith.md) — editing, voice extraction, narrative
-- [founder](docs/plugins/founder.md) — idea validation, pitch decks, financials
-- [career](docs/plugins/career.md) — interview prep, skill gaps, stakeholder navigation
-
-## Update
-
-```bash
-/plugin marketplace update moo.md
-```
+- [Learnings System](docs/learnings-system.md) — Insights persist across sessions
 
 ## Issues
 


### PR DESCRIPTION
## Summary

- Replace vague "Thoughtful plugins" tagline with concrete value prop
- Add Before/After table showing what actually changes
- Add verdict box example showing confidence gates in action
- Add "What Runs Quietly" section with silent audit checklist
- Convert plugin list to scannable table format
- De-emphasize learnings system (moved to Documentation section)

## Why

Reddit post got 0 engagement. Root cause: README didn't communicate core value. Visitors clicked through, saw vague copy, left.

## Changes Applied

- **elements-of-style**: Active voice, omit needless words, concrete language
- **wordsmith:edit**: Cut redundant parentheticals, varied repetitive verbs
- **Word reduction**: 203 → 178 words (12%)

## Test plan

- [ ] View README on GitHub - verify tables render correctly
- [ ] Verify verdict box alignment in code block
- [ ] Check all plugin links work