### PR TITLE
feat(hope): card carries what code can't re-derive, not durable facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- feat(hope): card admission rule reframed from "durable facts only" to "carry only what the next stage can't cheaply re-derive from the code in front of it" — a **recoverability test** replaces the blanket durability rule. Cheap local-code facts are re-read by the next stage, never carried (storing them is wasteful and rots); two kinds survive instead: decisions (underdetermined by code — only the human's goal settles them) and hard-won external facts (dependency/third-party behavior whose ground truth lives outside the codebase and cost steering to establish). Adds **carry-forward last**: the costly residue the human won't re-read — decisions and their reasons, paths ruled out, hard-won external facts — closes the card, captured when the stage locks so the next stage skips the work that produced them. Keeps moo out of the memory/storage business: the harness owns memory, code stays ground truth; the card only carries what code can't give the next session back cheaply
+
 ## [hope@8.0.0] - 2026-06-13
 
 ### Added

--- a/hope/skills/card.md
+++ b/hope/skills/card.md
@@ -1,12 +1,14 @@
 ## The card
 
-The pipeline's handoff artifact. One admission rule: durable facts only.
+The pipeline's handoff artifact. One admission rule: carry only what the next stage can't cheaply re-derive from the code in front of it.
 
 - **Checksum first** — open with one sentence: what this is, why it exists. Everything after is facts.
+- **Recoverability test** — admit a fact only if the next stage couldn't cheaply recover it by reading the code. Cheap local facts get re-read, never carried. Two kinds survive: decisions (code can't say why X over Y — only the human's goal settles it) and hard-won external facts (dependency or third-party behavior whose ground truth lives outside this codebase and cost steering to pin down).
 - **Vocabulary, not template** — sections (non-goals, acceptance, constraints, ...) appear only when the session produced them. No empty scaffolding, ever.
 - **Stranger test** — every fact must be understandable with zero session context.
 - **No temporal information** — no session narrative, no relative time ("currently", "for now"). Phrase decisions timelessly: "X over Y: reason". Absolute dates only when the fact IS a deadline.
-- **No volatile references** — concepts only. No file paths, function names, or line numbers; the next stage does its own retrieval.
+- **No volatile references** — concepts only. No file paths, function names, or line numbers. The next stage retrieves its own cheap local detail.
 - **No provenance markup** — provenance was visible live in the session, not encoded in the artifact.
+- **Carry-forward last** — the costly residue the human won't re-read closes the card: decisions and their reasons, paths ruled out (what was steered away from), and hard-won external facts. Captured when the stage locks so the next stage skips the work that produced them. The human reads it only if they want.
 - **Size by deletion, not cap** — a deletion pass in the gate audit governs length: every fact earns its place. Never a numeric limit.
 - **Storage-agnostic** — emit in conversation. Persisting it is the user's call.

--- a/hope/skills/intent/SKILL.md
+++ b/hope/skills/intent/SKILL.md
@@ -16,14 +16,16 @@ Clarify WHAT before building anything. Clarity over completeness — invented de
 <!-- doc-gen FILE src=../card.md -->
 ## The card
 
-The pipeline's handoff artifact. One admission rule: durable facts only.
+The pipeline's handoff artifact. One admission rule: carry only what the next stage can't cheaply re-derive from the code in front of it.
 
 - **Checksum first** — open with one sentence: what this is, why it exists. Everything after is facts.
+- **Recoverability test** — admit a fact only if the next stage couldn't cheaply recover it by reading the code. Cheap local facts get re-read, never carried. Two kinds survive: decisions (code can't say why X over Y — only the human's goal settles it) and hard-won external facts (dependency or third-party behavior whose ground truth lives outside this codebase and cost steering to pin down).
 - **Vocabulary, not template** — sections (non-goals, acceptance, constraints, ...) appear only when the session produced them. No empty scaffolding, ever.
 - **Stranger test** — every fact must be understandable with zero session context.
 - **No temporal information** — no session narrative, no relative time ("currently", "for now"). Phrase decisions timelessly: "X over Y: reason". Absolute dates only when the fact IS a deadline.
-- **No volatile references** — concepts only. No file paths, function names, or line numbers; the next stage does its own retrieval.
+- **No volatile references** — concepts only. No file paths, function names, or line numbers. The next stage retrieves its own cheap local detail.
 - **No provenance markup** — provenance was visible live in the session, not encoded in the artifact.
+- **Carry-forward last** — the costly residue the human won't re-read closes the card: decisions and their reasons, paths ruled out (what was steered away from), and hard-won external facts. Captured when the stage locks so the next stage skips the work that produced them. The human reads it only if they want.
 - **Size by deletion, not cap** — a deletion pass in the gate audit governs length: every fact earns its place. Never a numeric limit.
 - **Storage-agnostic** — emit in conversation. Persisting it is the user's call.
 <!-- end-doc-gen -->

--- a/hope/skills/shape/SKILL.md
+++ b/hope/skills/shape/SKILL.md
@@ -14,14 +14,16 @@ Decide HOW before building.
 <!-- doc-gen FILE src=../card.md -->
 ## The card
 
-The pipeline's handoff artifact. One admission rule: durable facts only.
+The pipeline's handoff artifact. One admission rule: carry only what the next stage can't cheaply re-derive from the code in front of it.
 
 - **Checksum first** — open with one sentence: what this is, why it exists. Everything after is facts.
+- **Recoverability test** — admit a fact only if the next stage couldn't cheaply recover it by reading the code. Cheap local facts get re-read, never carried. Two kinds survive: decisions (code can't say why X over Y — only the human's goal settles it) and hard-won external facts (dependency or third-party behavior whose ground truth lives outside this codebase and cost steering to pin down).
 - **Vocabulary, not template** — sections (non-goals, acceptance, constraints, ...) appear only when the session produced them. No empty scaffolding, ever.
 - **Stranger test** — every fact must be understandable with zero session context.
 - **No temporal information** — no session narrative, no relative time ("currently", "for now"). Phrase decisions timelessly: "X over Y: reason". Absolute dates only when the fact IS a deadline.
-- **No volatile references** — concepts only. No file paths, function names, or line numbers; the next stage does its own retrieval.
+- **No volatile references** — concepts only. No file paths, function names, or line numbers. The next stage retrieves its own cheap local detail.
 - **No provenance markup** — provenance was visible live in the session, not encoded in the artifact.
+- **Carry-forward last** — the costly residue the human won't re-read closes the card: decisions and their reasons, paths ruled out (what was steered away from), and hard-won external facts. Captured when the stage locks so the next stage skips the work that produced them. The human reads it only if they want.
 - **Size by deletion, not cap** — a deletion pass in the gate audit governs length: every fact earns its place. Never a numeric limit.
 - **Storage-agnostic** — emit in conversation. Persisting it is the user's call.
 <!-- end-doc-gen -->


### PR DESCRIPTION
## Why

The card was optimized to be human-readable by stripping retrievable info — good for the human, but it pushed the next stage into expensive re-retrieval and pulled the human back in to re-make choices they'd already made. Research into how the field handles cross-session handoff (agent memory, bi-temporal stores, delta state, decision/provenance logs) all converges on machinery that exists to compensate for the fact that **stored conclusions rot** — a tell that "give moo a memory" is the wrong move.

The sharper conclusion: moo shouldn't own memory or storage. The harness owns memory; **code is ground truth**. Re-deriving a fact from code is cheaper and *more* accurate than reconciling a stale cached copy. So the card should carry only what the next session **can't cheaply get back from the code in front of it.**

## What changed

The card's admission rule moves from "durable facts only" to a **recoverability test**:

- **Cheap local-code facts** → never carried. The next stage re-reads them; storing them is wasteful and rots the moment code changes.
- **Two kinds survive:**
  - **Decisions** — underdetermined by code; only the human's goal settles "X over Y".
  - **Hard-won external facts** — dependency/third-party behavior whose ground truth lives *outside* this codebase and cost steering to establish (the repeated step-in the human was feeling).

New **carry-forward last** rule: the costly residue the human won't re-read — decisions and their reasons, paths ruled out, hard-won external facts — closes the card. Captured when the stage locks so the next stage skips the work that produced them, and positioned at the end so the human reads it only if they want.

## Scope

- `hope/skills/card.md` — source of truth.
- `hope/skills/intent/SKILL.md`, `hope/skills/shape/SKILL.md` — the two md-magic-synced copies, updated **byte-identically** by hand (network-restricted env can't run `bun run sync`). Verified `diff` clean against the source, so a future `bun run sync` is a no-op.
- `CHANGELOG.md` — entry under `[Unreleased]`.

No new storage, no persistent state, no second artifact — the human still reads one card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qna74hQeVrgHQkrUTbAynP)_