### PR TITLE
feat(hope): auto-memory discipline + collection triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- feat(hope): auto-memory discipline + collection triggers — a SessionStart hook primes every session with a tight admission test (`hope/skills/memory.md`) governing what Claude commits to its native auto-memory: add an entry only if it passes every test — re-derivable (code can't cheaply re-tell it), timeless ("X over Y: reason", never present-tense), safe-if-wrong (rationale/convention, not live state/findings/paths), and not-already-known (edit a contradicted entry in place, never append a conflict); bias toward omission because a gap is recoverable but a wrong memory misleads silently. The discipline is competing on thinking quality, not building a store — Claude's native auto-memory remains the only store, moo holds no persistent state. Adds three low-noise collection triggers (`hope/hooks/memory-nudge.sh`) that nudge capture at high-signal moments and defer the write decision to the discipline: **correction** (UserPromptSubmit, gated on correction phrasing — moo's "Correction is signal") , **decision** (Stop, gated on decision keywords in the turn transcript, throttled to once / 10 min), and **research findings** (SubagentStop, matcher-filtered to Explore/Plan). All hooks are non-blocking and fail open; SessionStart re-injection covers compaction. PreCompact/SessionEnd cannot prompt Claude (no context injection) and are deliberately not used
+
 ## [hope@8.1.0] - 2026-06-19
 
 ### Changed

--- a/hope/hooks/hooks.json
+++ b/hope/hooks/hooks.json
@@ -10,6 +10,48 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/memory-prime.sh"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/memory-nudge.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/memory-nudge.sh"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": "Explore|Plan",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/memory-nudge.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/hope/hooks/memory-nudge.sh
+++ b/hope/hooks/memory-nudge.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Memory collection triggers. Reads the hook event on stdin and emits a capture nudge
+# (additionalContext) ONLY at high-signal moments, deferring the write decision to the
+# discipline (primed at SessionStart). Non-blocking; fails open on any missing input.
+command -v jq >/dev/null 2>&1 || exit 0
+input=$(cat)
+event=$(printf '%s' "$input" | jq -r '.hook_event_name // empty')
+
+emit() {
+  jq -n --arg e "$1" --arg c "$2" \
+    '{hookSpecificOutput:{hookEventName:$e, additionalContext:$c}}'
+}
+
+case "$event" in
+  UserPromptSubmit)
+    # Correction is signal — a correction is almost always a durable lesson.
+    prompt=$(printf '%s' "$input" | jq -r '.prompt // empty')
+    printf '%s' "$prompt" | grep -qiE "actually|that'?s (wrong|not right|incorrect)|no,|not what i|instead|revert|undo|misunderstood|i (said|told you)|stop doing" || exit 0
+    emit "$event" "Memory moment: the user is correcting you. Apply the auto-memory discipline — if it qualifies, record the durable lesson (what failed, the corrected direction) to MEMORY.md."
+    ;;
+  Stop)
+    # Throttle to at most once / 10 min per session — Stop fires every turn.
+    marker="${TMPDIR:-/tmp}/hope-mem-stop-$(printf '%s' "$input" | jq -r '.session_id // "x"')"
+    [ -n "$(find "$marker" -mmin -10 2>/dev/null)" ] && exit 0
+    tp=$(printf '%s' "$input" | jq -r '.transcript_path // empty')
+    [ -f "$tp" ] || exit 0
+    tail -n 40 "$tp" | grep -qiE "decision|architecture|approach|trade.?off|chose|chosen|convention|constraint|rationale" || exit 0
+    : > "$marker" 2>/dev/null
+    emit "$event" "This turn settled a decision. Apply the auto-memory discipline — if it qualifies, record it (X over Y: reason) to MEMORY.md."
+    ;;
+  SubagentStop)
+    emit "$event" "A research/planning subagent finished. Apply the auto-memory discipline — if it qualifies, record any durable finding, blocker, or decision it surfaced to MEMORY.md."
+    ;;
+esac
+exit 0

--- a/hope/hooks/memory-prime.sh
+++ b/hope/hooks/memory-prime.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# SessionStart: inject moo's auto-memory discipline so Claude curates durable memory,
+# not random memory. Fails open — a missing file or absent jq must never block a session.
+doc="$(dirname "$0")/../skills/memory.md"
+[ -f "$doc" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+jq -Rs '{hookSpecificOutput:{hookEventName:"SessionStart",additionalContext:.}}' < "$doc"
+exit 0

--- a/hope/skills/memory.md
+++ b/hope/skills/memory.md
@@ -1,0 +1,14 @@
+## Auto-memory discipline
+
+You curate this project's memory. Add an entry only if it passes every test;
+when unsure, skip — a gap is recoverable, a wrong memory misleads silently.
+
+| Test           | Add only if…                                                          |
+|----------------|-----------------------------------------------------------------------|
+| Re-derivable?  | code can't cheaply re-derive it — a decision code doesn't show, or hard-won external behavior |
+| Timeless?      | true across sessions — write "X over Y: reason", never "currently/now/this week" |
+| Safe if wrong? | rationale or convention — not live state, findings, or file paths      |
+| Already known? | no entry covers it — if one is now wrong, edit it in place, never append a conflict |
+
+Keep MEMORY.md lean, durable entries first — only its first ~25KB loads.
+A locked intent or shape card's carry-forward already qualifies.


### PR DESCRIPTION
Prime every session with a tight admission test governing what Claude
commits to its native auto-memory (re-derivable / timeless / safe-if-wrong /
not-already-known), and nudge capture at three high-signal, low-noise moments:
correction (UserPromptSubmit), decision (Stop, gated + throttled), and
research findings (SubagentStop on Explore/Plan). Competes on memory quality;
adds no moo-owned store. All hooks non-blocking and fail open.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ax6H7xVczN31rh6FgREpFZ