### PR TITLE
feat(hope): inline ownership at the moment of return (8.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [hope@8.2.0] - 2026-06-20
+
+### Added
+
+- feat(hope): inline ownership at the moment of return — /delegate gains a RETURN act that fires when a verified delegation reports GO and the diff embodies a decision (recoverability test; mechanical diffs skip silently). The human authors a re-answerable prompt (question→answer, not a description — recall builds the model, a summary read once does not), Decision lens by default ("what did this decide / what path did it rule out") with an invariant/boundary/failure lens offered only for structural or core-domain diffs. The prompt appends to the existing /own ledger as a new `authored` event (mechanical jq, atomic write, distinct delegate-origin id) — no new store, reusing own's persistent-state carve-out. /own re-probes authored concepts via transformation instead of inventing generic questions, so the spaced ritual stops being abstract; authoring never counts as a pass, so it never promotes a concept to owned (authoring ≠ owning). Closes the gap where delegated work returned faster than the human could own it: the moment work returns becomes the moment it is claimed
+- feat(hope): return.sh PostToolUse hook (matcher `Agent|Workflow`) — a reinforcement-only nudge injecting one suppressed line that reminds the router to run the RETURN act before surfacing a verified return; a hook cannot author or capture (it only injects additionalContext), so it reinforces the skill instruction, never replaces it; fails open
+
+### Changed
+
+- feat(hope): own ledger schema gains an `authored` outcome (seed prompt, no grade); rank.jq folds it to a k=0 no-op via the existing else branch (documentation-only change) so an authored concept schedules like new work but never promotes to owned; own SKILL.md — survey treats authored concepts as already-in-ledger (fuzzy-match folds duplicates), the first probe transforms the authored prompt, and the invisibility rule extends to the `authored` outcome
+- feat(hope): delegate router contract carves out the single mechanical ledger append that records an authored return; DISPATCH now scopes each delegation to return a reviewable unit (a wall of output can be neither verified nor claimed)
+
 ## [hope@8.1.0] - 2026-06-19
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,6 +16,13 @@
   - Decision pending: fix in SKILL.md or accept as behavior (user testing will inform)
 
 ## Decisions
+- [x] Inline ownership at the moment of return — /delegate RETURN act + own `authored` ledger event (2026-06-20)
+  - Gap (session research + user interview): delegated work returns faster than the human can own it; /own was skipped and "abstract, not grounded"; /delegate verify was the heaviest tax — all three resolve at one point, the verified return
+  - Fold comprehension into /delegate's verified-GO return, gated by the recoverability test — only decision-bearing diffs probe, mechanical diffs skip (the "lighter than /own, not heavier" guard)
+  - Human authors a re-answerable prompt (Decision lens default, DDD invariant/boundary lens opt-in for structural diffs) → appended to the existing own ledger as an `authored` event; /own re-probes it later via transformation
+  - Consult panel insight (matuschak/vygotsky/evans): framing is second-order — a description authored once builds no durable memory; the artifact must be a re-answerable prompt on a schedule. A diff IS a decision, so the Decision lens fits the unit; DDD vocabulary stamped on every diff manufactures false language (the DDD advocate argued against defaulting to it)
+  - Constraints held: authoring ≠ owning (authored events never promote to owned); reuses own's carve-out, no new store; never gates or blocks the merge; moo surfaces the decision, never authors the code
+  - Reinforcement hook (return.sh) is the one piece reintroducing hook machinery v4 shed — kept minimal (one suppressed nudge on Agent|Workflow returns), reinforcement-only because a hook cannot author or capture, only inject context
 - [x] hope v4 rewrite complete — 10 skills / ~1380 lines → 4 skills / 147 lines (2026-03-01)
   - Removed: loop, soul, verify, observe, forge, search
   - Rewrote: intent (22L), shape (23L), consult (67L), bond (35L). Full is command-only.

--- a/hope/.claude-plugin/plugin.json
+++ b/hope/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "hope",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "description": "Thinking discipline for AI work. Clarify intent, shape approach, consult experts, guard unsupervised work, audit against principles.",
   "keywords": ["intent", "shape", "consult", "target", "distill", "expert", "workflow", "audit"],
   "author": {

--- a/hope/hooks/hooks.json
+++ b/hope/hooks/hooks.json
@@ -10,6 +10,17 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Agent|Workflow",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/return.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/hope/hooks/return.sh
+++ b/hope/hooks/return.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Return nudge: after a subagent or workflow returns, remind the router to run
+# the RETURN act on a decision-bearing diff before surfacing it. Reinforcement
+# ONLY — a hook cannot author or capture; it injects one suppressed line of
+# context (see delegate RETURN). Fails open: any error must never brick the
+# Agent/Workflow tool, so always exit 0 with valid JSON.
+cat <<'JSON'
+{
+  "suppressOutput": true,
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "Verified subagent work returned. If this diff embodies a decision (recoverability test), run the RETURN act before surfacing — have the human author a re-answerable prompt and append it to the own ledger as an authored event. Mechanical diffs skip."
+  }
+}
+JSON
+exit 0

--- a/hope/skills/delegate/SKILL.md
+++ b/hope/skills/delegate/SKILL.md
@@ -10,7 +10,7 @@ You are now a ROUTER, not a worker. You spawn agents and verify their output. Yo
 
 **The test for work:** does the action touch files, shell, the web, or code? Then it is WORK — delegate it. Never do it yourself.
 
-**You may call directly only:** tools that spawn agents, run workflows, or ask the user (orchestration + clarification). Nothing else.
+**You may call directly only:** tools that spawn agents, run workflows, ask the user (orchestration + clarification), or run the single mechanical ledger append that records an authored return (see RETURN). Nothing else.
 
 **Before every action, ask:** am I about to do work myself? If yes — stop, write a prompt, delegate.
 
@@ -26,6 +26,8 @@ Construct prompts for speed, correctness, and efficiency.
 - **Self-contained prompts.** A fresh agent starts blind. Give it durable facts, not fragile pointers: what to achieve, the constraints, why it matters, what is out of scope. Name identifiers and behaviors, not line numbers — let the agent locate them.
 - **Workflow-first for 2+ agents.** Any multi-agent work runs through a Workflow, not loose agent calls.
 
+- **Return reviewable units.** Scope each delegation so its diff comes back small enough to read and own — a wall of output can be neither verified nor claimed. Width and output caps serve reviewability, not just cost.
+
 **Clean slate is the default.** Spawn a fresh subagent_type for almost all work. Fork (no subagent_type) only in the rare case the agent genuinely needs your accumulated context to do the job.
 
 ## VERIFY
@@ -34,3 +36,12 @@ You did not watch the work happen — an agent's summary is what it INTENDED, no
 
 - **Every work delegation pairs a verify-agent.** No delegation ships unverified.
 - **The verifier returns a verdict, not a dump:** GO or NOGO + one-line REASON grounded in what it observed (tests, command exit, behavior). Keep the evidence in the agent; surface only the verdict.
+
+## RETURN
+
+Verified work returns to you, not past you. When a delegation reports GO, decide whether the diff carries a decision before surfacing it — the moment work returns is the moment you claim it.
+
+- **Gate on decision.** Apply the recoverability test: is the code indifferent between ≥2 paths, with the human's goal — not a retrievable fact — breaking the tie? Mechanical or re-derivable diffs skip this section silently. Only decision-bearing diffs continue. This gate is the friction guard; most returns skip.
+- **The human authors, in your thread.** Surface the decision the diff embodies in 1-2 lines, then have the human write a re-answerable prompt (question → answer), not a description — the recall, not the summary, builds the model. Default lens: what did this decide, what path did it rule out. Offer an invariant / boundary / failure lens only when the diff is structural or touches the core domain.
+- **Append, never block.** Write the authored prompt to the own ledger — mechanical jq, `date -u`, atomic `> tmp && mv`, outcome `authored`, a distinct delegate-origin id. Concept named in the project's language, one-line re-locatable description (no volatile refs). The merge proceeds regardless; declining to author records nothing. own re-probes the authored prompt on its next run, so the spaced ritual rests on concepts the human wrote, not generic ones.
+- **You stay the router.** Authorship is the human's, done in the main thread — never delegated to a subagent. The append is bookkeeping, not work.

--- a/hope/skills/own/SKILL.md
+++ b/hope/skills/own/SKILL.md
@@ -16,7 +16,7 @@ Probe the human's understanding of their own codebase so they keep the capacity 
 ## Invisibility (load-bearing)
 
 - Never surface due dates, streaks, mastery labels, or any interval-derived signal. The moment one leaks, the schedule stops measuring forgetting and starts manufacturing performance — and reverts to a fixed staleness window.
-- k, interval, priority, assisted/owned status: scheduling internals, model-facing only.
+- k, interval, priority, assisted/owned status, the `authored` seed outcome: scheduling internals, model-facing only. Never surface "you wrote this at return time."
 
 ## Ledger
 
@@ -42,6 +42,7 @@ Rules:
 - Probe question text is stored verbatim — the audit trail that each re-probe is a genuine transformation, never a rephrase.
 - Concept name + one-line description only — no volatile code references. A concept that can't be re-located from its description has a bad description.
 - Concepts are named in the project's language. Fresh extractions fuzzy-match existing entries (tombstones included); a match reuses the canonical entry.
+- Authored events (outcome `authored`) are written at delegate-return time, not by a debrief — they seed a concept with the re-answerable prompt the human wrote. The first debrief probe of an authored concept transforms that prompt (`transformedFrom` = the authored event's id). Authoring never counts as a pass, so it never promotes a concept to owned.
 
 ### Merges
 
@@ -62,7 +63,7 @@ Derive the slug, apply the adoption rule — announce any adoption move. Cold st
 Characterize-first, budget-scoped — scoped by the question budget, never the repo:
 
 1. Re-verify the sampled ledger concepts against current code: present / changed / gone. A "changed" verdict is recorded as an event (it resets the schedule — prior passes no longer attest to current code). Can't find it → ask the user; never silently record gone.
-2. Then look for new work.
+2. Then look for new work — concepts not already in the ledger. Authored concepts already sit in the ledger; a fresh extraction fuzzy-matches the existing authored entry rather than creating a duplicate.
 
 **Diff hint** — `git diff <last-debrief-commit>..HEAD` is a locator hint only, trusted iff BOTH: (a) the last debrief's commit exists, (b) it is an ancestor of HEAD. Either check fails → drop the hint, say so, proceed ledger-only. The hint may speed the survey; it never decides a verdict.
 

--- a/hope/skills/own/ledger.schema.json
+++ b/hope/skills/own/ledger.schema.json
@@ -37,7 +37,7 @@
       "properties": {
         "debriefId": {
           "type": "string",
-          "description": "One id generated per debrief run, stamped on every event that run writes — distinct-debrief counts are exact group_by(.debriefId), never timestamp clustering."
+          "description": "One id generated per debrief run, stamped on every event that run writes — distinct-debrief counts are exact group_by(.debriefId), never timestamp clustering. Authored events (written by /delegate, not a debrief) carry a distinct delegate-origin id; since owned-derivation counts only pass events, authored ids never inflate it."
         },
         "timestamp": {
           "type": "string",
@@ -50,15 +50,15 @@
         },
         "question": {
           "type": ["string", "null"],
-          "description": "Verbatim probe question text — the audit trail that each re-probe is a genuine transformation, never a rephrase. Null only for survey verdicts (outcome=changed) where no question was asked."
+          "description": "Verbatim probe question text — the audit trail that each re-probe is a genuine transformation, never a rephrase. Null only for survey verdicts (outcome=changed) where no question was asked; for outcome=authored it holds the re-answerable prompt the human wrote at return time."
         },
         "transformedFrom": {
           "type": ["string", "null"],
           "description": "Reference to the prior probe this question transforms (debriefId of the source event); null for a concept's first probe and for survey verdicts."
         },
         "outcome": {
-          "enum": ["pass", "fail", "changed"],
-          "description": "pass/fail grade the model assigned, or the survey's 'changed' verdict (code moved out from under the concept)."
+          "enum": ["pass", "fail", "changed", "authored"],
+          "description": "pass/fail grade the model assigned; the survey's 'changed' verdict (code moved out from under the concept); or 'authored' — a self-authored seed prompt written at delegate-return time, carrying no grade. An authored event seeds the schedule (folds to k=0 in rank.jq) and is never a pass, so it never promotes a concept to owned. Authoring is not owning."
         }
       }
     },

--- a/hope/skills/own/rank.jq
+++ b/hope/skills/own/rank.jq
@@ -14,6 +14,9 @@
 # k: ordered fold over events. +1 per pass, -1 per fail clamped at 0
 # (halve the interval, never reset), reset to 0 on a "changed" verdict
 # (code moved out from under the concept; prior passes no longer attest).
+# An "authored" seed event hits the else branch: no-op (k unchanged), so a
+# freshly authored concept sits at k=0 / assisted with a real lastProbe — it
+# schedules like new work but never counts as a pass, so it never promotes.
 def k_fold:
   reduce .events[] as $e (0;
     if   $e.outcome == "pass"    then . + 1


### PR DESCRIPTION
Fold a decision-gated comprehension act into /delegate's verified-return
path: when a delegation reports GO and the diff embodies a decision
(recoverability test; mechanical diffs skip), the human authors a
re-answerable prompt that appends to the existing /own ledger as an
`authored` event. /own re-probes it later, so the spaced ritual rests on
concepts the human wrote, not generic ones. Authoring never counts as a
pass, so it never promotes to owned (authoring != owning); the merge
never blocks.

Adds the own ledger `authored` outcome (rank.jq folds it to a k=0 no-op
via the existing else branch) and a reinforcement-only return.sh
PostToolUse hook. Reuses own's persistent-state carve-out -- no new store.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TBSumBYL3QFgpMjSDiazUw